### PR TITLE
__construct supports passing in Client, but passing in GuzzleHttp\Cli…

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -159,7 +159,7 @@ class Telegram
      */
     private bool $enableEvents = false;
 
-    public function __construct(string $token, ?TelegramHttpClientInterface $client = null)
+    public function __construct(string $token, ?ClientInterface $client = null)
     {
         $this->token = $token;
         $this->apiClient = $client ?? new Client();


### PR DESCRIPTION
__construct supports passing in Client, but passing in GuzzleHttp\Client will report an error